### PR TITLE
[TASK] TYPO3 CMS 13 support

### DIFF
--- a/Classes/Service/GarbageCollectorService.php
+++ b/Classes/Service/GarbageCollectorService.php
@@ -2,8 +2,7 @@
 
 namespace KKSoftware\IndexedSearchGC\Service;
 
-
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Statement;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Log\Logger;
@@ -98,9 +97,9 @@ class GarbageCollectorService
     }
 
     /**
-     * @param int $phash
+     * @param int|string $phash
      */
-    protected function deleteData(int $phash)
+    protected function deleteData(int|string $phash)
     {
         $counter = 0;
 
@@ -108,7 +107,7 @@ class GarbageCollectorService
 
         foreach ($this->statements as $statement) {
             $statement->bindValue(1, $phash);
-            $result = $statement->execute();
+            $result = $statement->executeQuery();
 
             $counter += $result->rowCount();
         }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^12.4",
-    "typo3/cms-indexed-search": "^12.4",
-    "typo3/cms-scheduler": "^12.4"
+    "typo3/cms-core": "^12.4 || ^13.4",
+    "typo3/cms-indexed-search": "^12.4 || ^13.4",
+    "typo3/cms-scheduler": "^12.4 || ^13.4"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master"


### PR DESCRIPTION
As there are no breaking / deprecated changes between TYPO3 v12 and TYPO3 v13 in this extension, adjusting the icomposer dependencies should enough to make it compatible with TYPO3 13.4.